### PR TITLE
Update S3 backend configuration and outputs for RDS module

### DIFF
--- a/infra/data.tf
+++ b/infra/data.tf
@@ -1,8 +1,8 @@
 data "terraform_remote_state" "network" {
   backend = "s3"
   config = {
-    bucket = "terraform-state-bucket-nextime"
-    key    = "infra.tfstate"
+    bucket = "nextime-food-state-bucket"
+    key    = "infra-core/infra.tfstate"
     region = "us-east-1"
   }
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -2,3 +2,13 @@ output "rds_endpoint" {
   description = "Endpoint do banco de dados RDS"
   value       = module.rds_instance.rds_endpoint
 }
+
+output "rds_username" {
+  description = "Usuário do RDS"
+  value       = module.rds_instance.rds_username
+}
+
+output "rds_password_ssm_param" {
+  description = "Caminho do SSM Parameter Store com a senha do RDS"
+  value       = var.rds_password_ssm_path
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -4,11 +4,15 @@ terraform {
       source  = "hashicorp/aws"
       version = "6.14.1"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.7.2"
+    }
   }
 
   backend "s3" {
-    bucket  = "terraform-state-bucket-nextime"
-    key     = "database.tfstate"
+    bucket  = "nextime-food-state-bucket"
+    key     = "infra-database/infra.tfstate"
     region  = "us-east-1"
     encrypt = true
   }
@@ -18,3 +22,4 @@ terraform {
 provider "aws" {
   region = "us-east-1"
 }
+


### PR DESCRIPTION
 
This pull request updates the Terraform infrastructure configuration to improve state management and output information. The main changes involve updating S3 bucket and key paths for remote state storage, adding new outputs for RDS credentials, and including a new provider.

**State Management Updates:**
* Changed the S3 bucket and key paths for both the remote state data source (`terraform_remote_state "network"`) and the backend configuration to use `nextime-food-state-bucket` and more descriptive key paths. [[1]](diffhunk://#diff-6c743bcd12d6276d700990dd31a6196e5cfd8ce64dd18c40f7420bc1c59f0de9L4-R5) [[2]](diffhunk://#diff-5ef2e72c22257cca42070d8444ab4d0cd556361db3bcec5056b90b9ca7aadda7R7-R15)

**Outputs Enhancements:**
* Added new outputs for `rds_username` and `rds_password_ssm_param` to expose the RDS username and the SSM Parameter Store path for the RDS password.

**Provider Configuration:**
* Added the `random` provider with version `3.7.2` to the required providers block.
* Minor formatting update to the `aws` provider block (added a newline).